### PR TITLE
I1211: Correct responsibility_status from 'approved' to 'incomplete'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: jenner
 Title: Internal Montagu Helpers
-Version: 0.0.6
+Version: 0.0.7
 Description: Helpers for Montagu.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+### jenner 0.0.7 (2017-12-14)
+ * In `create_touchstone.R`, correct responsibility status from 'approved' to 'incomplete'. 'incompelte' is the default status when a new touchstone is open.
+
 ### jenner 0.0.6 (2017-11-22)
  * create synthetic fvps for situations where - fvps is blank but given coverage 
 

--- a/R/create_touchstone.R
+++ b/R/create_touchstone.R
@@ -80,7 +80,7 @@ create_touchstone <- function(con, dat, demography_from = NULL,
   meta <- c("modelling_group", "touhstone", "status")
   resp_set <- data_frame(modelling_group = unique(dat_meta$modelling_group),
                          touchstone = touchstone_id,
-                         status = "approved")
+                         status = "incomplete")
   append_table(con, "responsibility_set", resp_set)
 
   ## import responsibility - leave current_burden_estimate_set empty


### PR DESCRIPTION
Youtrack link
https://vimc.myjetbrains.com/youtrack/issue/VIMC-1211

Task:
Correct responsibility_status from 'approved' to 'incomplete'. Because 'incomplete' is the default status when a new touchstone is open.