### PR TITLE
I1591:  improve jenner  for modified update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: jenner
 Title: Internal Montagu Helpers
-Version: 0.0.11
+Version: 0.0.12
 Description: Helpers for Montagu.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 ### jenner 0.0.12
  * VIMC-1591 add more routine vaccine age 
- * VIMC-1591 undo the constrain on coverage_old
+ * VIMC-1591 undo the constrain on coverage_old when touchstone_new = touchstone_old
+ * VIMC-1591 add three columns in the output for method2 impact calculation - population, fvps and coverage
+ 
 ### jenner 0.0.11
  * VIMC-1380 method 2 impact calculation  
  * Currently impact calculation is assisted by .csv recipe; this will be changed when recipe is imported montagu

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+### jenner 0.0.12
+ * VIMC-1591 add more routine vaccine age 
+ * VIMC-1591 undo the constrain on coverage_old
 ### jenner 0.0.11
  * VIMC-1380 method 2 impact calculation  
  * Currently impact calculation is assisted by .csv recipe; this will be changed when recipe is imported montagu

--- a/R/impact_method2.R
+++ b/R/impact_method2.R
@@ -211,18 +211,18 @@ make_impact <- function(con, index, year_min, year_max, routine_tot_rate_shape =
   impact1 <- dat[cols_impact1]
 
   ## 2) aggrefated impact
-  cols_impact2 <- c("index", "impact_type","support_type", "country", "vaccine", "year", "tot_rate", "impact")
+  cols_impact2 <- c("index", "vaccine", "impact_type","support_type", "country", "year", "coverage", "population", "fvps","tot_rate", "impact")
   # impact by birth cohort
-  impact_cohort <- stats::aggregate(impact ~ index + support_type + country + vaccine + cohort + tot_rate, data=dat, sum, na.rm=TRUE)
+  impact_cohort <- stats::aggregate(cbind(population, fvps, impact) ~ index + support_type + country + vaccine + cohort + tot_rate, data=dat, sum, na.rm=TRUE)
   impact_cohort$impact_type <- "cohort"
   names(impact_cohort)[which(names(impact_cohort) == "cohort")] <- "year"
   impact_cohort <- impact_cohort[impact_cohort$year %in% (cohort_min:cohort_max), ]
   # # impact by year of vaccination
-  impact_calendar <- stats::aggregate(impact ~ index + support_type + country + vaccine + year + tot_rate, data=dat, sum, na.rm=TRUE)
+  impact_calendar <- stats::aggregate(cbind(population, fvps, impact) ~ index + support_type + country + vaccine + year + tot_rate, data=dat, sum, na.rm=TRUE)
   impact_calendar$impact_type <- "calendar"
   impact_calendar <- impact_calendar[impact_calendar$year %in% (year_min:year_max), ]
   impact2 <- rbind(impact_cohort, impact_calendar)
-
+  impact2$coverage <- impact2$fvps / impact2$population
   impact2 <- impact2[cols_impact2]
   ## 6. End
   return( list(impact_full = impact1, impact_simplified = impact2) )

--- a/R/modified_update.R
+++ b/R/modified_update.R
@@ -21,7 +21,8 @@ modified_update_calculate <- function(con, touchstone_name_mod, touchstone_use) 
   touchstone_mod <- DBI::dbGetQuery(con, sql, touchstone_name_mod)
     i <- touchstone_mod$id != '201510gavi-42'
     touchstone_mod <- touchstone_mod[which.max(touchstone_mod$version[i]), ]
-  meta <- mu_prepare(con, touchstone_mod$id)
+  modup_by_itself <- any(touchstone_name_mod == touchstone_use)
+  meta <- mu_prepare(con, touchstone_mod$id, modup_by_itself = modup_by_itself)
   meta <- mu_impact_metadata(meta, touchstone_use)
 
   meta$touchstone_mod <-
@@ -192,9 +193,16 @@ modified_update_summary_output <- function(con, res, path_meta) {
   ret
 }
 
-mu_prepare <- function(con, touchstone_new) {
+mu_prepare <- function(con, touchstone_new, modup_by_itself = FALSE) {
   ## NOTE: duplicated from orderly - could pull out there and remove
   ## this duplication later.
+  ## sometimes we do modup for touchstone_old = touchstone_new
+  ## the if-else clause is important to deal with this
+  if(modup_by_itself) {
+    touchstone_new2 <- "201802uxe-1"
+  } else {
+    touchstone_new2 <- touchstone_new
+  }
   temporary_view <- function(name, sql) {
     sprintf("CREATE TEMPORARY VIEW v_%s AS\n%s", name, sql)
   }
@@ -202,7 +210,8 @@ mu_prepare <- function(con, touchstone_new) {
                           mustWork = TRUE)
   read_sql <- function(name) {
     txt <- read_file(file.path(path_sql, paste0(name, ".sql")))
-    whisker::whisker.render(txt, list(touchstone_new = touchstone_new))
+    whisker::whisker.render(txt, list(touchstone_new2 = touchstone_new2, 
+                                      touchstone_new = touchstone_new))
   }
 
   views <- c("migrate_coverage", "burden_fvps", "impact", "coverage",

--- a/R/modified_update.R
+++ b/R/modified_update.R
@@ -199,7 +199,7 @@ mu_prepare <- function(con, touchstone_new, modup_by_itself = FALSE) {
   ## sometimes we do modup for touchstone_old = touchstone_new
   ## the if-else clause is important to deal with this
   if(modup_by_itself) {
-    touchstone_new2 <- "201802uxe-1"
+    touchstone_new2 <- NULL
   } else {
     touchstone_new2 <- touchstone_new
   }

--- a/inst/sql/modified_update/migrate_coverage.sql
+++ b/inst/sql/modified_update/migrate_coverage.sql
@@ -4,7 +4,7 @@ coverage_old.activity_type,
 coverage_old.id AS coverage_set_id_old,
 coverage_new.id AS coverage_set_id_new
 FROM (SELECT * FROM coverage_set
-      WHERE touchstone != '{{{touchstone_new}}}') AS coverage_old
+WHERE touchstone != '{{{touchstone_new2}}}') AS coverage_old
 LEFT JOIN (SELECT coverage_set.* FROM coverage_set
 JOIN touchstone ON touchstone.id = coverage_set.touchstone
            WHERE touchstone = '{{{touchstone_new}}}'

--- a/inst/sql/modified_update/target_pop_routine.sql
+++ b/inst/sql/modified_update/target_pop_routine.sql
@@ -16,7 +16,7 @@ SELECT demographic_statistic.demographic_source,
 -- This will need expanding if we need further detail but this will
 -- hopefully do for now (and will make the queries a little easier to
 -- deal with)
-   AND age_from IN (0, 1, 2, 9)
+   AND age_from IN (0, 1, 2, 9, 10, 11, 12)
 --   AND year BETWEEN 2001 AND 2016
 --   AND country IN ('KEN', 'ZWE')
  ORDER BY demographic_source, age_from, country, year


### PR DESCRIPTION
Youtrack:
https://vimc.myjetbrains.com/youtrack/issue/VIMC-1400

Tasks:
 *  change constrain in migrate_coverage.sql for cases where touchstone_new = touchstone_old;
 *  add routine vaccine age types
 * add three columns in the output for method2 impact calculation - population, fvps and coverage

Tested with orderly reports?
Yes. Tested changes with report `internal-2017-modup2-201510gavi-201510gavi`. In this report, touchstone_old = touchstone_new = 201510gavi. Previously, modup for LSHTM-HepB and Harvard-HPV were not calculated. With the changes made, they are retrieved.
Also tested the impact calculation method2 in an orderly report.

