### PR TITLE
i1831: ignore touchstone version 42 in fix_coverage_fvps() function 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: jenner
 Title: Internal Montagu Helpers
-Version: 0.0.15
+Version: 0.0.16
 Description: Helpers for Montagu.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
-
+### jenner 0.0.16
+ * VIMC-1831 ignore touchstone version -42, so that fix_coverage_fvps can be reusable for other touchstones
+ 
 ### jenner 0.0.15
- * VIMC-14628 impact_method2 sql modification post Wes' touchstone fast forward
+ * VIMC-1684 impact_method2 sql modification post Wes' touchstone fast forward
 
 ### jenner 0.0.13
  * VIMC-1611 constrain the number of countries for HepB impact calculation - because different scenarios have different number of countries 

--- a/R/impact_method2.R
+++ b/R/impact_method2.R
@@ -363,7 +363,7 @@ fix_coverage_fvps <- function(con, touchstone_name = "201710gavi", year_min = 20
   ## 1. touchstone specification
   # given touchstone name, use the latest version touchstone
   version <- DBI::dbGetQuery(con, "SELECT MAX(touchstone.version) as version FROM touchstone
-                             WHERE touchstone_name = $1", touchstone_name)
+                             WHERE touchstone_name = $1 AND version != 42", touchstone_name)
   touchstone <- DBI::dbGetQuery(con, "SELECT id FROM touchstone
                                 WHERE touchstone_name = $1
                                 AND version = $2", list(touchstone_name, version$version))


### PR DESCRIPTION
Youtrack:
https://vimc.myjetbrains.com/youtrack/issue/VIMC-1831

Task:
 ignore touchstone version 42 in fix_coverage_fvps() function, so that the function can be used for other touchstones.