### PR TITLE
i1976: add population touchstone  as an extra parameter to fix_coverage_fvps

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: jenner
 Title: Internal Montagu Helpers
-Version: 0.0.17
+Version: 0.0.18
 Description: Helpers for Montagu.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+### jenner 0.0.18
+ * VIMC-1976 allow differnt coverage touchstone and population touchstone, so that fix_coverage_fvps function can be flexibly used for interim update
+ 
 ### jenner 0.0.17
  * VIMC-1758 constrain gavi_support_level to bestminus and gavi, so that fix_coverage_fvps function can be flexibly used for interim update
 

--- a/inst/sql/impact_method2_metadata/coverage_pop.sql
+++ b/inst/sql/impact_method2_metadata/coverage_pop.sql
@@ -37,7 +37,7 @@ JOIN demographic_statistic_type
   ON demographic_statistic_type.id = demographic_statistic.demographic_statistic_type
 JOIN gender
   ON gender.id = demographic_statistic.gender
-WHERE touchstone_demographic_dataset.touchstone = $1
+WHERE touchstone_demographic_dataset.touchstone = $4
 %2s
   AND demographic_statistic_type.code = 'int_pop'
   AND year BETWEEN $2 AND $3) AS un_population

--- a/man/fix_coverage_fvps.Rd
+++ b/man/fix_coverage_fvps.Rd
@@ -6,7 +6,7 @@
 \usage{
 fix_coverage_fvps(con, touchstone_name = "201710gavi", year_min = 2000,
   year_max = 2100, pine = FALSE, write_table = TRUE,
-  report_suspecious_coverage = FALSE)
+  report_suspecious_coverage = FALSE, touchstone_pop = NULL)
 }
 \arguments{
 \item{con}{Database connection.  You will need to be \code{readonly} user
@@ -23,6 +23,9 @@ to run this function.}
 \item{write_table}{If true, create a temporary table; otherwise return a dataframe}
 
 \item{report_suspecious_coverage}{switch on/off the reporting of suspecious coverage}
+
+\item{touchstone_pop}{population touchstone, this is for the modups
+where fvps are calculated using a coverage touchstone and a population touchstone}
 }
 \description{
 Provide age-specific coverage-un_pop-fvps


### PR DESCRIPTION
Task:
add population touchstone as an extra parameter to fix_coverage_fvps to make the function useable for interim update

Youtrack:
https://vimc.myjetbrains.com/youtrack/issue/VIMC-1976

@richfitz. For the interim update, I need both coverage touchstone and population touchstone to calculate FVPS. So I am adding one extra parameter in `fix_coverage_fvps` function. To make sure this change does not influence elsewhere that used this function, I put this new parameter at the end of the function accompany with a if-clause within the function.
