### PR TITLE
I2172: fixing native impact rates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: jenner
 Title: Internal Montagu Helpers
-Version: 0.0.19
+Version: 0.0.20
 Description: Helpers for Montagu.
 License: MIT + file LICENSE
 Author: Rich FitzJohn

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+### jenner 0.0.20
+ * Required by VIMC-2172. Fixing native impact rates (routine) where there are fvps given, but NA deaths averted, which casued under-estimation of impact rates.
+ 
 ### jenner 0.0.19
  * Required by VIMC-1892.Allows impact calcualation to include maxium age of interest.
  

--- a/R/modified_update.R
+++ b/R/modified_update.R
@@ -518,7 +518,7 @@ mu_calculate_rate <- function(name, dat, window, n_years, activity_type) {
   v_tot <- sprintf("%s_averted_rate_tot", name)
   v_use <- sprintf("%s_averted_rate", name)
   v_type <- sprintf("%s_averted_rate_type", name)
-  ## there are cases where there are fvps but blank deaths/cases averted, whcih cause under-estimation of impact rates
+  ## there are fvps but blank deaths/cases averted, which cause under-estimation of impact rates
   ## in these cases, we should remove fvps from impact rates calculation.
   ## a small trick for this is here:
   d <- dat

--- a/inst/sql/modified_update/migrate_coverage.sql
+++ b/inst/sql/modified_update/migrate_coverage.sql
@@ -9,6 +9,8 @@ LEFT JOIN (SELECT coverage_set.* FROM coverage_set
 JOIN touchstone ON touchstone.id = coverage_set.touchstone
            WHERE touchstone = '{{{touchstone_new}}}'
            AND (coverage_set.gavi_support_level = 'with'
-             OR coverage_set.gavi_support_level = 'bestminus') )AS coverage_new
+             OR coverage_set.gavi_support_level = 'bestminus') 
+          AND NOT coverage_set.name IN ('mr_measles-campaign-bestminus', 'Hib: MCV1, with, routine',
+          'Rota: MCV1, with, routine', 'PCV: MCV1, with, routine'))AS coverage_new
 ON coverage_old.vaccine = coverage_new.vaccine AND
 coverage_old.activity_type = coverage_new.activity_type

--- a/tests/testthat/impact.csv
+++ b/tests/testthat/impact.csv
@@ -108,11 +108,11 @@ index,touchstone,modelling_group,disease,vaccine,impact_outcome,activity_type,na
 107,201710gavi-5,LSHTM-Clark,Rota,Rota,dalys_averted,routine,dalys_averted_total_routine,rota-routine-gavi,rota-no-vaccination,dalys,TRUE,FALSE,
 108,201710gavi-5,LSHTM-Clark,Rota,Rota,deaths_averted,routine,deaths_averted_total_routine,rota-routine-gavi,rota-no-vaccination,deaths,TRUE,FALSE,
 109,201710gavi-5,PHE-Vynnycky,Rubella,Rubella,cases_averted,campaign,cases_averted_total_campaign,rubella-campaign-gavi,rubella-routine-no-vaccination,rubella_cases_congenital,TRUE,FALSE,
-110,201710gavi-5,PHE-Vynnycky,Rubella,Rubella,cases_averted,routine,cases_averted_total_routine,rubella-routine-gavi,rubella-campaign-gavi,rubella_cases_congenital,TRUE,FALSE,"RCV1 is treated as focal, not RCV2"
+110,201710gavi-5,PHE-Vynnycky,Rubella,Rubella,cases_averted,routine,cases_averted_total_routine,rubella-rcv2-gavi,rubella-campaign-gavi,rubella_cases_congenital,TRUE,FALSE,"RCV1 is treated as focal, not RCV2"
 111,201710gavi-5,PHE-Vynnycky,Rubella,Rubella,dalys_averted,campaign,dalys_averted_total_campaign,rubella-campaign-gavi,rubella-routine-no-vaccination,dalys,TRUE,FALSE,
-112,201710gavi-5,PHE-Vynnycky,Rubella,Rubella,dalys_averted,routine,dalys_averted_total_routine,rubella-routine-gavi,rubella-campaign-gavi,dalys,TRUE,FALSE,"RCV1 is treated as focal, not RCV2"
+112,201710gavi-5,PHE-Vynnycky,Rubella,Rubella,dalys_averted,routine,dalys_averted_total_routine,rubella-rcv2-gavi,rubella-campaign-gavi,dalys,TRUE,FALSE,"RCV1 is treated as focal, not RCV2"
 113,201710gavi-5,PHE-Vynnycky,Rubella,Rubella,deaths_averted,campaign,deaths_averted_total_campaign,rubella-campaign-gavi,rubella-routine-no-vaccination,rubella_deaths_congenital,TRUE,FALSE,
-114,201710gavi-5,PHE-Vynnycky,Rubella,Rubella,deaths_averted,routine,deaths_averted_total_routine,rubella-routine-gavi,rubella-campaign-gavi,rubella_deaths_congenital,TRUE,FALSE,"RCV1 is treated as focal, not RCV2"
+114,201710gavi-5,PHE-Vynnycky,Rubella,Rubella,deaths_averted,routine,deaths_averted_total_routine,rubella-rcv2-gavi,rubella-campaign-gavi,rubella_deaths_congenital,TRUE,FALSE,"RCV1 is treated as focal, not RCV2"
 115,201710gavi-5,IC-Garske,YF,YF,cases_averted,campaign,cases_averted_total_campaign,yf-preventive-gavi,yf-no-vaccination,cases,TRUE,FALSE,
 116,201710gavi-5,IC-Garske,YF,YF,cases_averted,routine,cases_averted_total_routine,yf-routine-gavi,yf-preventive-gavi,cases,TRUE,FALSE,
 117,201710gavi-5,IC-Garske,YF,YF,dalys_averted,campaign,dalys_averted_total_campaign,yf-preventive-gavi,yf-no-vaccination,dalys,TRUE,FALSE,


### PR DESCRIPTION
Required by VIMC-2172
https://vimc.myjetbrains.com/youtrack/issue/VIMC-2172

Task:
1. fix native impact rates
2. constrain coverage_new to make report running again

Tested:
Yes, tested with report `modup-201710` locally.

 