### PR TITLE
extend campaign years for cholera

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: jenner
 Title: Internal Montagu Helpers
-Version: 0.0.26
+Version: 0.0.27
 Description: Helpers for Montagu.
 License: MIT + file LICENSE
 Author: Rich FitzJohn
@@ -12,7 +12,7 @@ Imports:
     vaultr (>= 0.2.0),
     whisker,
     yaml
-RoxygenNote: 6.1.1
+RoxygenNote: 7.3.2
 Suggests:
     RSQLite,
     testthat (>= 1.0.2)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## jenner 0.0.27
+* vimc-7551. Allow campaign year to be extended beyond 2030.
+
 ### jenner 0.0.26
  * VIMC-2755. Allow dalys life table and parameter objects to be reused for subsequent runs. (For stochastic performance)
 

--- a/R/dalys.R
+++ b/R/dalys.R
@@ -56,7 +56,6 @@ calculate_dalys <- function(con, touchstone_name, year_min = 2000, year_max = 20
   dat[cols]
 }
 
-##' @inherit calculate_dalys
 ##' @rdname calculate_dalys
 ##' @export
 create_dalys_parameters <- function(con, touchstone_name = "201710gavi", vimc_dalys_only) {
@@ -85,7 +84,6 @@ create_dalys_parameters <- function(con, touchstone_name = "201710gavi", vimc_da
   dalys_src[cols]
 }
 
-##' @inherit calculate_dalys
 ##' @rdname calculate_dalys
 ##' @export
 create_dalys_life_table <- function(con, touchstone_name = "201710gavi", year_min = 2000, year_max = 2030) {

--- a/R/impact_method2.R
+++ b/R/impact_method2.R
@@ -9,7 +9,7 @@
 ##' @param year_max maximal year year of vaccination
 ##' @param routine_tot_rate_shape This parameter determines how we chop off the year-age matrix to calculate impact rates
 ##' campaign is stratiforward, use all fvps and all burden estimates to calculate impact rate. So no need to specify.
-##' Becuase all impacts (years 2000-2100) are derived from campaigns between 2000 and 2030.
+##' Becuase all impacts (years 2000-2100) are derived from campaigns between 2000 and 2030 (relaxed for Cholera).
 ##' Routine is more complicated. We either trance birth cohort between 2000-2030 or trance all birth cohorts between 2000-2100.
 ##' @param method impact calculation method - chose from method1 and method2
 ##' impact outcome can be provided as age specific if simplified=FALSE
@@ -192,7 +192,7 @@ make_impact <- function(con, index, year_min, year_max, routine_tot_rate_shape =
 
   if (activity_type == "campaign"){
     shape <- paste(sprintf("AND year BETWEEN %s", 2000),
-                   sprintf(" AND %s", 2030), sep = "\n")
+                   sprintf(" AND %s", year_max), sep = "\n")
   }else{
     if (routine_tot_rate_shape == "trace_cohort"){
       shape <- paste(sprintf("AND year BETWEEN %s", year_min),

--- a/man/calculate_dalys.Rd
+++ b/man/calculate_dalys.Rd
@@ -6,15 +6,26 @@
 \alias{create_dalys_life_table}
 \title{DALYs calculation}
 \usage{
-calculate_dalys(con, touchstone_name, year_min = 2000, year_max = 2030,
-  vimc_dalys_only = TRUE, modelling_group = NULL,
-  stochastic_data = NULL, dalys_parameters = NULL, life_table = NULL)
+calculate_dalys(
+  con,
+  touchstone_name,
+  year_min = 2000,
+  year_max = 2030,
+  vimc_dalys_only = TRUE,
+  modelling_group = NULL,
+  stochastic_data = NULL,
+  dalys_parameters = NULL,
+  life_table = NULL
+)
 
-create_dalys_parameters(con, touchstone_name = "201710gavi",
-  vimc_dalys_only)
+create_dalys_parameters(con, touchstone_name = "201710gavi", vimc_dalys_only)
 
-create_dalys_life_table(con, touchstone_name = "201710gavi",
-  year_min = 2000, year_max = 2030)
+create_dalys_life_table(
+  con,
+  touchstone_name = "201710gavi",
+  year_min = 2000,
+  year_max = 2030
+)
 }
 \arguments{
 \item{con}{You can be \code{readonly} user to run this function.

--- a/man/create_touchstone.Rd
+++ b/man/create_touchstone.Rd
@@ -4,8 +4,14 @@
 \alias{create_touchstone}
 \title{Create a new touchstone}
 \usage{
-create_touchstone(con, dat, demography_from = NULL, path_meta = "meta",
-  transaction = TRUE, dry_run = TRUE)
+create_touchstone(
+  con,
+  dat,
+  demography_from = NULL,
+  path_meta = "meta",
+  transaction = TRUE,
+  dry_run = TRUE
+)
 }
 \arguments{
 \item{con}{Database connection.  You will need to be the

--- a/man/database_connection.Rd
+++ b/man/database_connection.Rd
@@ -4,8 +4,12 @@
 \alias{database_connection}
 \title{Connect to database}
 \usage{
-database_connection(location = "science", user = "readonly",
-  local_port = NULL, local_password_group = "science")
+database_connection(
+  location = "science",
+  user = "readonly",
+  local_port = NULL,
+  local_password_group = "science"
+)
 }
 \arguments{
 \item{location}{One of "science", "production", "uat" or

--- a/man/fix_coverage_fvps.Rd
+++ b/man/fix_coverage_fvps.Rd
@@ -4,10 +4,17 @@
 \alias{fix_coverage_fvps}
 \title{Impact Calculation (method 2)}
 \usage{
-fix_coverage_fvps(con, touchstone_name = "201710gavi", year_min = 2000,
-  year_max = 2100, pine = FALSE, write_table = TRUE,
-  report_suspecious_coverage = FALSE, touchstone_pop = NULL,
-  gavi_support_levels = c("with", "bestminus"))
+fix_coverage_fvps(
+  con,
+  touchstone_name = "201710gavi",
+  year_min = 2000,
+  year_max = 2100,
+  pine = FALSE,
+  write_table = TRUE,
+  report_suspecious_coverage = FALSE,
+  touchstone_pop = NULL,
+  gavi_support_levels = c("with", "bestminus")
+)
 }
 \arguments{
 \item{con}{Database connection.  You will need to be \code{readonly} user

--- a/man/impact_calculation.Rd
+++ b/man/impact_calculation.Rd
@@ -4,9 +4,15 @@
 \alias{impact_calculation}
 \title{Impact Calculation (method 2)}
 \usage{
-impact_calculation(con, meta, year_min = 2000, year_max = 2030,
-  routine_tot_rate_shape = "trace_cohort", method = "method2",
-  age_max = 100)
+impact_calculation(
+  con,
+  meta,
+  year_min = 2000,
+  year_max = 2030,
+  routine_tot_rate_shape = "trace_cohort",
+  method = "method2",
+  age_max = 100
+)
 }
 \arguments{
 \item{con}{Database connection.  You will need to be \code{readonly} user
@@ -20,7 +26,7 @@ to run this function.}
 
 \item{routine_tot_rate_shape}{This parameter determines how we chop off the year-age matrix to calculate impact rates
 campaign is stratiforward, use all fvps and all burden estimates to calculate impact rate. So no need to specify.
-Becuase all impacts (years 2000-2100) are derived from campaigns between 2000 and 2030.
+Becuase all impacts (years 2000-2100) are derived from campaigns between 2000 and 2030 (relaxed for Cholera).
 Routine is more complicated. We either trance birth cohort between 2000-2030 or trance all birth cohorts between 2000-2100.}
 
 \item{method}{impact calculation method - chose from method1 and method2

--- a/man/project_coverage.Rd
+++ b/man/project_coverage.Rd
@@ -4,8 +4,7 @@
 \alias{project_coverage}
 \title{Project coverage}
 \usage{
-project_coverage(dat, year_project_from, year_from = 1980,
-  year_to = 2100)
+project_coverage(dat, year_project_from, year_from = 1980, year_to = 2100)
 }
 \arguments{
 \item{dat}{Data with columns...}


### PR DESCRIPTION
This is to let year_max be flexible for campaigns - so that cholera can be accomodated.
We are not going to re-use jenner for YoV, BUT, this is really to make the 201910 impact calculations re-runable and corrected for Cholera.